### PR TITLE
Implement FavoriteListScreen

### DIFF
--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Linking } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { DiffInfo, PostHistoricalResponse, PostInfo } from '../types';
+import { DiffInfo, PostHistoricalResponse, PostInfo, MyPostHistoricalResponse } from '../types';
 
 type PostCardProps = {
-  post: PostInfo | PostHistoricalResponse;
+  post: PostInfo | PostHistoricalResponse | MyPostHistoricalResponse;
   showBookmark?: boolean;
   isBookmarked?: boolean;
   onBookmark?: () => void;

--- a/screens/FavoriteListScreen.tsx
+++ b/screens/FavoriteListScreen.tsx
@@ -1,14 +1,58 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ActivityIndicator, FlatList } from 'react-native';
+import { ROUTES, useFavoriteNavigation } from '../navigation';
+import { MyPostHistoricalResponse } from '../types';
+import api from '../utils/api';
+import { PostCard } from '../components/PostCard';
 
 export default function FavoriteListScreen() {
+  const navigation = useFavoriteNavigation();
+  const [posts, setPosts] = useState<MyPostHistoricalResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadFavorites = async () => {
+    setLoading(true);
+    try {
+      const res = await api.get<{ data: MyPostHistoricalResponse[] }>(
+        '/my/posts/favorite'
+      );
+      setPosts(res.data);
+    } catch (err) {
+      console.error('Fetch favorites failed:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadFavorites();
+  }, []);
+
+  if (loading) {
+    return (
+      <View style={styles.loader}>
+        <ActivityIndicator size="large" />
+        <Text>載入中...</Text>
+      </View>
+    );
+  }
+
   return (
-    <View style={styles.container}>
-      <Ionicons name='construct-outline' size={48} color='#1976d2' style={styles.icon} />
-      <Text style={styles.title}>即將推出</Text>
-      <Text style={styles.subtitle}>這裡會是你收藏的精華文章✨</Text>
-    </View>
+    <FlatList
+      contentContainerStyle={styles.container}
+      data={posts}
+      keyExtractor={(item) => item.id.toString()}
+      renderItem={({ item }) => (
+        <PostCard
+          post={item}
+          onPress={() =>
+            navigation.navigate(ROUTES.Favorite.FavoriteDetail, { item })
+          }
+        />
+      )}
+      refreshing={loading}
+      onRefresh={loadFavorites}
+    />
   );
 }
 
@@ -16,20 +60,10 @@ const styles = StyleSheet.create({
   container: {
     flexGrow: 1,
     padding: 16,
+  },
+  loader: {
+    flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-  },
-  icon: {
-    marginBottom: 16,
-  },
-  title: {
-    fontSize: 20,
-    fontWeight: '700',
-    color: '#1976d2',
-    marginBottom: 4,
-  },
-  subtitle: {
-    fontSize: 14,
-    color: '#555',
   },
 });

--- a/types/index.ts
+++ b/types/index.ts
@@ -18,6 +18,14 @@ export interface PostHistoricalResponse extends PostInfo {
   highest?: DiffInfo;
 }
 
+export interface MyPostHistoricalResponse extends PostHistoricalResponse {
+  cost?: number;
+  shares?: number;
+  notes?: string;
+  profit: number | null;
+  profitRate?: number | null;
+}
+
 export interface DiffInfo {
   date: string;
   diff: number;


### PR DESCRIPTION
## Summary
- add `MyPostHistoricalResponse` interface
- extend `PostCard` to accept `MyPostHistoricalResponse`
- implement `FavoriteListScreen` fetching `/my/posts/favorite`

## Testing
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6840057828808327901e6f55354e3ffb