### PR TITLE
Refactor lists and auth to Recoil

### DIFF
--- a/states/authState.ts
+++ b/states/authState.ts
@@ -1,0 +1,14 @@
+import { atom } from 'recoil';
+
+export type AuthState = {
+  isLoggedIn: boolean;
+  account: string | null;
+};
+
+export const authState = atom<AuthState>({
+  key: 'authState',
+  default: {
+    isLoggedIn: false,
+    account: null,
+  },
+});

--- a/states/authorsState.ts
+++ b/states/authorsState.ts
@@ -1,0 +1,11 @@
+import { selector } from 'recoil';
+import api from '../utils/api';
+import { LeaderboardItem } from '../types';
+
+export const authorsState = selector<LeaderboardItem[]>({
+  key: 'authorsState',
+  get: async () => {
+    const res = await api.get<LeaderboardItem[]>('/my/authors/rank');
+    return res.data;
+  },
+});

--- a/states/postsState.ts
+++ b/states/postsState.ts
@@ -1,0 +1,11 @@
+import { selector } from 'recoil';
+import api from '../utils/api';
+import { PostInfo } from '../types';
+
+export const postsState = selector<PostInfo[]>({
+  key: 'postsState',
+  get: async () => {
+    const res = await api.get<{ posts: PostInfo[] }>('/ptt/posts');
+    return res.data.posts;
+  },
+});


### PR DESCRIPTION
## Summary
- manage login status via new `authState`
- add `authorsState` and `postsState` selectors that fetch data from API
- refactor `useAuth` to update Recoil auth state
- update list screens to use Recoil selectors

## Testing
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6841312ea0148327a658b55e34fed6df