### PR TITLE
Implement search in PostList screen

### DIFF
--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,0 +1,61 @@
+import React, { useState, useEffect } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+
+export type SearchBarProps = {
+  onDebouncedTextChange?: (text: string) => void;
+  onSearch?: (text: string) => void;
+  loading?: boolean;
+};
+
+export default function SearchBar({
+  onDebouncedTextChange,
+  onSearch,
+  loading,
+}: SearchBarProps) {
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      onDebouncedTextChange?.(text);
+    }, 300);
+    return () => clearTimeout(handler);
+  }, [text, onDebouncedTextChange]);
+
+  const handleChangeText = (t: string) => {
+    setText(t);
+    if (t === '') {
+      onDebouncedTextChange?.('');
+    }
+  };
+
+  const handleSearchPress = () => {
+    onSearch?.(text);
+  };
+
+  return (
+    <View style={styles.row}>
+      <TextInput
+        placeholder='搜尋文章標題'
+        value={text}
+        onChangeText={handleChangeText}
+        style={styles.input}
+        returnKeyType='search'
+        onSubmitEditing={handleSearchPress}
+      />
+      <Button title='搜尋' onPress={handleSearchPress} disabled={loading} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: { flexDirection: 'row', alignItems: 'center', marginBottom: 12 },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    marginRight: 8,
+    height: 40,
+  },
+});

--- a/screens/PostListScreen.tsx
+++ b/screens/PostListScreen.tsx
@@ -1,15 +1,50 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View, Text, FlatList, StyleSheet, ActivityIndicator } from 'react-native';
 
 import { usePostNavigation, ROUTES } from '../navigation';
 import { PostCard } from '../components/PostCard';
 import { useRecoilRefresher_UNSTABLE, useRecoilValueLoadable } from 'recoil';
 import { postsState } from '../states/postsState';
+import api from '../utils/api';
+import { PostInfo } from '../types';
+import SearchBar from '../components/SearchBar';
 
 export default function PostListScreen() {
   const navigation = usePostNavigation();
   const postsLoadable = useRecoilValueLoadable(postsState);
   const refresh = useRecoilRefresher_UNSTABLE(postsState);
+
+  const [filterText, setFilterText] = useState('');
+  const [searchResults, setSearchResults] = useState<PostInfo[] | null>(null);
+  const [searchLoading, setSearchLoading] = useState(false);
+
+  const handleChangeText = (text: string) => {
+    setFilterText(text);
+    if (text === '') {
+      setSearchResults(null);
+    } else {
+      // clear previous results so local filter will be used until search is pressed
+      setSearchResults(null);
+    }
+  };
+
+  const handleSearch = async (text: string) => {
+    if (!text.trim()) {
+      setSearchResults(null);
+      return;
+    }
+    try {
+      setSearchLoading(true);
+      const res = await api.get<{ posts: PostInfo[] }>(
+        `/my/posts/search?search=${encodeURIComponent(text)}`
+      );
+      setSearchResults(res.data.posts);
+    } catch (err) {
+      console.error('Search posts failed:', err);
+    } finally {
+      setSearchLoading(false);
+    }
+  };
 
   if (postsLoadable.state === 'loading') {
     return (
@@ -29,14 +64,29 @@ export default function PostListScreen() {
   }
 
   const posts = postsLoadable.contents;
+  const filteredPosts = filterText
+    ? posts.filter((p) => p.title.includes(filterText))
+    : posts;
+  const data: PostInfo[] =
+    filterText === '' ? posts : searchResults ?? filteredPosts;
 
   return (
     <FlatList
+      ListHeaderComponent={
+        <SearchBar
+          onDebouncedTextChange={handleChangeText}
+          onSearch={handleSearch}
+          loading={searchLoading}
+        />
+      }
       contentContainerStyle={styles.container}
-      data={posts}
+      data={data}
       keyExtractor={(item) => item.id.toString()}
       renderItem={({ item }) => (
-        <PostCard post={item} onPress={() => navigation.navigate(ROUTES.Post.PostDetail, { post: item })} />
+        <PostCard
+          post={item}
+          onPress={() => navigation.navigate(ROUTES.Post.PostDetail, { post: item })}
+        />
       )}
       refreshing={postsLoadable.state === ('loading' as any)}
       onRefresh={refresh}


### PR DESCRIPTION
## Summary
- add search bar and API search in `PostListScreen`
- split search bar into separate component and debounce input

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842a12d98e883278765efc75f8f4253