### PR TITLE
Improve notification navigation handling

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { View, Text, StyleSheet, Alert, Button, ActivityIndicator } from 'react-native';
 import AppNavigator from './navigation/AppNavigator';
 import { navigateToAuthorDetail, navigateToPostDetail, navigationRef } from './navigation/navigationRef';
+import PendingAuthorNavigator from './components/PendingAuthorNavigator';
 import api from './utils/api';
 import { clearStorage } from './utils/storage';
 import { useAuth } from './hooks/useAuth';
@@ -85,6 +86,7 @@ function AppWithState() {
       {/* 導航主畫面 */}
       <View style={styles.navigator}>
         <AppNavigator isLoggedIn={isLoggedIn} />
+        <PendingAuthorNavigator />
       </View>
 
       {/* 推播 Token 區塊 */}

--- a/components/PendingAuthorNavigator.tsx
+++ b/components/PendingAuthorNavigator.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { pendingAuthorState } from '../states/pushNotificationState';
+import { navigationReadyState } from '../states/navigationState';
+import { navigateToAuthorDetail } from '../navigation/navigationRef';
+
+export default function PendingAuthorNavigator() {
+  const navigationReady = useRecoilValue(navigationReadyState);
+  const [pendingAuthor, setPendingAuthor] = useRecoilState(pendingAuthorState);
+
+  useEffect(() => {
+    if (navigationReady && pendingAuthor) {
+      navigateToAuthorDetail(pendingAuthor);
+      setPendingAuthor(null);
+    }
+  }, [navigationReady, pendingAuthor, setPendingAuthor]);
+
+  return null;
+}

--- a/hooks/usePushNotifications.ts
+++ b/hooks/usePushNotifications.ts
@@ -6,13 +6,12 @@ import Constants from 'expo-constants';
 import { Platform } from 'react-native';
 import { navigationRef, navigateToAuthorDetail } from '../navigation/navigationRef';
 import { PostInfo } from '../types';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import {
   lastNotificationState,
   pushTokenState,
   pendingAuthorState,
 } from '../states/pushNotificationState';
-import { navigationReadyState } from '../states/navigationState';
 
 
 // https://docs.expo.dev/versions/latest/sdk/notifications/
@@ -20,7 +19,6 @@ export function usePushNotifications() {
   const [expoPushToken, setExpoPushToken] = useRecoilState(pushTokenState);
   const setNotification = useSetRecoilState(lastNotificationState);
   const [pendingAuthor, setPendingAuthor] = useRecoilState(pendingAuthorState);
-  const navigationReady = useRecoilValue(navigationReadyState);
 
   const notificationListener = useRef<Notifications.EventSubscription>();
   const responseListener = useRef<Notifications.EventSubscription>();
@@ -67,13 +65,6 @@ export function usePushNotifications() {
     };
   }, [setExpoPushToken, setNotification, setPendingAuthor]);
 
-  // 在導航就緒且存在待處理作者時進行跳轉
-  useEffect(() => {
-    if (navigationReady && pendingAuthor && navigationRef.isReady()) {
-      navigateToAuthorDetail(pendingAuthor);
-      setPendingAuthor(null);
-    }
-  }, [navigationReady, pendingAuthor, setPendingAuthor]);
 
   return {
     expoPushToken,

--- a/navigation/AppNavigator.tsx
+++ b/navigation/AppNavigator.tsx
@@ -11,6 +11,8 @@ import PostStack from './stack/PostStack';
 import FavoriteStack from './stack/FavoriteStack';
 import AuthorStack from './stack/AuthorStack';
 import { navigationRef } from './navigationRef';
+import { useSetRecoilState } from 'recoil';
+import { navigationReadyState } from '../states/navigationState';
 
 const RootStack = createNativeStackNavigator<RootStackParamList>();
 const Tab = createBottomTabNavigator<RootTabParamList>();
@@ -49,8 +51,13 @@ const MainTabs = () => (
 );
 
 export default function AppNavigator({ isLoggedIn }: Props) {
+  const setNavigationReady = useSetRecoilState(navigationReadyState);
+
   return (
-    <NavigationContainer ref={navigationRef}>
+    <NavigationContainer
+      ref={navigationRef}
+      onReady={() => setNavigationReady(true)}
+    >
       <RootStack.Navigator screenOptions={{ headerShown: false }}>
         {isLoggedIn ? (
           <RootStack.Screen name={ROUTES.Root.MainTabs} component={MainTabs} />

--- a/states/navigationState.ts
+++ b/states/navigationState.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const navigationReadyState = atom<boolean>({
+  key: 'navigationReadyState',
+  default: false,
+});

--- a/states/pushNotificationState.ts
+++ b/states/pushNotificationState.ts
@@ -1,5 +1,6 @@
 import { atom } from 'recoil';
 import * as Notifications from 'expo-notifications';
+import { LeaderboardItem } from '../types';
 
 export const pushTokenState = atom<string | null>({
   key: 'pushTokenState',
@@ -8,5 +9,10 @@ export const pushTokenState = atom<string | null>({
 
 export const lastNotificationState = atom<Notifications.Notification | null>({
   key: 'lastNotificationState',
+  default: null,
+});
+
+export const pendingAuthorState = atom<LeaderboardItem | string | null>({
+  key: 'pendingAuthorState',
   default: null,
 });


### PR DESCRIPTION
## Summary
- store pending notification author in Recoil
- track when navigation is ready
- navigate to AuthorDetail when pending notification exists and navigation is ready
- remove unused navigation listener

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685915947d988327b3bbeba7d4f7b825